### PR TITLE
make keyword optional in getCourses

### DIFF
--- a/app/server/src/routes/course/course.controller.js
+++ b/app/server/src/routes/course/course.controller.js
@@ -14,29 +14,35 @@ const CourseController = {
         image
       );
       res.status(201).send({ course });
-    }
-    catch (e) {
-      res.status(400).send({ "error": e })
+    } catch (e) {
+      res.status(400).send({ error: e });
     }
   },
 
   getCourses: async function (req, res) {
     try {
-      const keyword = req.params.keyword
-      const courses = await CourseModel.Course.find({
-        name: { $regex: keyword, $options: "i" },
-      }).populate("name rating image lecturer").exec();
+      const { keyword } = req.params;
+      var courses;
+      if (keyword) {
+        courses = await CourseModel.Course.find({
+          name: { $regex: keyword, $options: "i" },
+        })
+          .populate("name rating image lecturer")
+          .exec();
+      } else {
+        courses = await CourseModel.Course.find({})
+          .populate("name rating image lecturer")
+          .exec();
+      }
       return res.status(200).json({ courses });
-      
-    }
-    catch (error) {
-      res.status(400).send({ "error": error.toString() })
+    } catch (error) {
+      res.status(400).send({ error: error.toString() });
     }
   },
 
   getCourseDetail: async function (req, res) {
     try {
-      const id = req.params.id
+      const id = req.params.id;
       const course = await CourseModel.Course.findById(id)
         .populate("name info rating lecturer tags chapters image")
         .exec();
@@ -45,16 +51,18 @@ const CourseController = {
       let data = {
         course,
       };
-      const enrollingInfo = await EnrollmentModel.Enrollment.find({ course_id: id, user_id: user._id })
+      const enrollingInfo = await EnrollmentModel.Enrollment.find({
+        course_id: id,
+        user_id: user._id,
+      });
       if (enrollingInfo) {
-        data.enrolled = true
+        data.enrolled = true;
       } else {
-        data.enrolled = false
+        data.enrolled = false;
       }
       return res.status(200).json({ data });
-    }
-    catch (e) {
-      res.status(400).send({ "error": e.toString() })
+    } catch (e) {
+      res.status(400).send({ error: e.toString() });
     }
   },
 };

--- a/app/server/src/routes/course/course.route.js
+++ b/app/server/src/routes/course/course.route.js
@@ -15,7 +15,7 @@ courseRouter.post(
 );
 
 courseRouter.get(
-  "/getCourses/:keyword",
+  "/getCourses/:keyword?",
   // validate("getCourses"),
   // handleValidation,
   authorization,


### PR DESCRIPTION
`keyword` of `getCourses` (residing at `/course/getCourses/:keyword`) currently requires keyword to be entered, although the front-end team wants it to be optional. I changed `:keyword` to `:keyword?` to achieve this. I also added a conditional flow to the database query done in the function. 