### PR TITLE
remove authorization from get function 'course/:id'

### DIFF
--- a/app/server/src/routes/course/course.route.js
+++ b/app/server/src/routes/course/course.route.js
@@ -21,7 +21,6 @@ courseRouter.get(
 
 courseRouter.get(
   "/:id",
-  authorization,
   CourseController.getCourseDetail
 );
 


### PR DESCRIPTION
Front-end wants that the _GET_ function `course/:id` need not require authorization.