### PR TITLE
backend: confirm-mail no longer needs email

### DIFF
--- a/app/server/src/routes/enrollment/enrollment.controller.js
+++ b/app/server/src/routes/enrollment/enrollment.controller.js
@@ -26,6 +26,13 @@ const EnrollmentController = {
       var data = [];
       for (var enrolled_course of enrolled_courses) {
         var course = await CourseModel.Course.findById(enrolled_course.course_id)
+        .populate("name info rating lecturer tags chapters image")
+        .populate({
+          path: 'chapters',
+          populate: {
+            path: 'chapter_badge',
+          }
+        }).exec();
         data.push(course);
       }
       return res.status(200).json({ data });

--- a/app/server/src/routes/user/user.validate.js
+++ b/app/server/src/routes/user/user.validate.js
@@ -24,7 +24,6 @@ exports.validate = (method) => {
         }
         case "confirm-email": {
             return [
-                body("email", "email does not exist").exists().isEmail(),
                 body("code", "code does not exist").exists().isJWT(),
             ];
         }


### PR DESCRIPTION
Small update on confirm-mail endpoint. It no longer needs email, only uses given token for confirming.