### PR TITLE
Mobile/note-sharing

### DIFF
--- a/app/mobile/android/app/src/main/AndroidManifest.xml
+++ b/app/mobile/android/app/src/main/AndroidManifest.xml
@@ -46,4 +46,5 @@
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <uses-permission android:name="android.permission.INTERNET"/>
 </manifest>

--- a/app/mobile/android/build.gradle
+++ b/app/mobile/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.7.20'
     repositories {
         google()
         mavenCentral()

--- a/app/mobile/lib/classes/course/course.dart
+++ b/app/mobile/lib/classes/course/course.dart
@@ -25,7 +25,8 @@ class Course {
   final Color color = CustomColors.getRandomColor();
   // final DateTime createdAt;
 
-  Course(this.name, this.id, this.info, this.tags, this.image, this.creator, this.numberOfEnrolled);
+  Course(this.name, this.id, this.info, this.tags, this.image, this.creator,
+      this.numberOfEnrolled);
 
   factory Course.fromJson(Map<String, dynamic> json) => _$CourseFromJson(json);
 
@@ -37,10 +38,20 @@ class CourseDetailed extends Course {
   List<Topic> topics = [];
   List<String> badges = [];
   List<DiscussionShortened> discussions = [];
-  List<Note>? notes = [];
+  List<Note?>? notes = [];
 
-  CourseDetailed(super.name, super.id, super.info, super.tags, super.image,
-      super.creator, super.numberOfEnrolled, this.topics, this.badges, this.discussions, this.notes);
+  CourseDetailed(
+      super.name,
+      super.id,
+      super.info,
+      super.tags,
+      super.image,
+      super.creator,
+      super.numberOfEnrolled,
+      this.topics,
+      this.badges,
+      this.discussions,
+      this.notes);
 
   factory CourseDetailed.fromJson(Map<String, dynamic> json) =>
       _$CourseDetailedFromJson(json);

--- a/app/mobile/lib/classes/course/course.g.dart
+++ b/app/mobile/lib/classes/course/course.g.dart
@@ -43,7 +43,8 @@ CourseDetailed _$CourseDetailedFromJson(Map<String, dynamic> json) =>
           .map((e) => DiscussionShortened.fromJson(e as Map<String, dynamic>))
           .toList(),
       (json['notes'] as List<dynamic>?)
-          ?.map((e) => Note.fromJson(e as Map<String, dynamic>))
+          ?.map((e) =>
+              e == null ? null : Note.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 

--- a/app/mobile/lib/classes/note/note.dart
+++ b/app/mobile/lib/classes/note/note.dart
@@ -1,3 +1,5 @@
+import 'package:bucademy/classes/resource/resource.dart';
+import 'package:bucademy/classes/user/user.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'note.g.dart';
@@ -14,9 +16,12 @@ class Note {
   final String id;
 
   @JsonKey(name: 'resource')
-  final String resourceId;
+  final ResourceShortened resource;
 
-  Note(this.title, this.body, this.id, this.resourceId);
+  @JsonKey(name: 'creator')
+  final User creator;
+
+  Note(this.title, this.body, this.id, this.resource, this.creator);
   factory Note.fromJson(Map<String, dynamic> json) => _$NoteFromJson(json);
 
   Map<String, dynamic> toJson() => _$NoteToJson(this);

--- a/app/mobile/lib/classes/note/note.g.dart
+++ b/app/mobile/lib/classes/note/note.g.dart
@@ -10,12 +10,14 @@ Note _$NoteFromJson(Map<String, dynamic> json) => Note(
       json['title'] as String,
       json['body'] as String,
       json['_id'] as String,
-      json['resource'] as String,
+      ResourceShortened.fromJson(json['resource'] as Map<String, dynamic>),
+      User.fromJson(json['creator'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$NoteToJson(Note instance) => <String, dynamic>{
       'title': instance.title,
       'body': instance.body,
       '_id': instance.id,
-      'resource': instance.resourceId,
+      'resource': instance.resource,
+      'creator': instance.creator,
     };

--- a/app/mobile/lib/classes/resource/resource.dart
+++ b/app/mobile/lib/classes/resource/resource.dart
@@ -35,9 +35,27 @@ class Resource {
   @JsonKey(name: 'updatedAt')
   final DateTime updatedAt;
 
-  Resource(this.id, this.name, this.body,this.topic, this.creator, this.averageRating, this.createdAt, this.updatedAt);
+  Resource(this.id, this.name, this.body, this.topic, this.creator,
+      this.averageRating, this.createdAt, this.updatedAt);
 
-  factory Resource.fromJson(Map<String, dynamic> json) => _$ResourceFromJson(json);
+  factory Resource.fromJson(Map<String, dynamic> json) =>
+      _$ResourceFromJson(json);
 
   Map<String, dynamic> toJson() => _$ResourceToJson(this);
+}
+
+@JsonSerializable()
+class ResourceShortened {
+  @JsonKey(name: '_id')
+  final String id;
+
+  @JsonKey(name: 'name')
+  final String name;
+
+  ResourceShortened(this.id, this.name);
+
+  factory ResourceShortened.fromJson(Map<String, dynamic> json) =>
+      _$ResourceShortenedFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ResourceShortenedToJson(this);
 }

--- a/app/mobile/lib/classes/resource/resource.g.dart
+++ b/app/mobile/lib/classes/resource/resource.g.dart
@@ -27,3 +27,15 @@ Map<String, dynamic> _$ResourceToJson(Resource instance) => <String, dynamic>{
       'createdAt': instance.createdAt.toIso8601String(),
       'updatedAt': instance.updatedAt.toIso8601String(),
     };
+
+ResourceShortened _$ResourceShortenedFromJson(Map<String, dynamic> json) =>
+    ResourceShortened(
+      json['_id'] as String,
+      json['name'] as String,
+    );
+
+Map<String, dynamic> _$ResourceShortenedToJson(ResourceShortened instance) =>
+    <String, dynamic>{
+      '_id': instance.id,
+      'name': instance.name,
+    };

--- a/app/mobile/lib/resources/constants.dart
+++ b/app/mobile/lib/resources/constants.dart
@@ -1,6 +1,7 @@
 class Constants {
   static const borderRadius = 14.0;
   static const backendUrl = "http://3.72.116.99:5000";
+  static const frontendUrl = "https://bucademy.tk";
 }
 
 String fullImagePath(String? filename) =>

--- a/app/mobile/lib/services/note_service.dart
+++ b/app/mobile/lib/services/note_service.dart
@@ -1,5 +1,3 @@
-import 'package:bucademy/classes/discussion/comment.dart';
-import 'package:bucademy/classes/discussion/discussion.dart';
 import 'package:bucademy/classes/note/note.dart';
 import 'package:bucademy/services/locator.dart';
 import 'package:dio/dio.dart';
@@ -19,7 +17,7 @@ class NoteService {
       );
 
       Map json = response.data;
-      return Note.fromJson(json['note']);
+      return await getNote(noteId: json['note']['_id']);
     } catch (e) {
       print(e);
     }
@@ -42,7 +40,7 @@ class NoteService {
     return null;
   }
 
-  Future<List<Note>> notesOfSpace({
+  Future<List<Note?>> notesOfSpace({
     required String spaceId,
   }) async {
     if (userService.user == null) {
@@ -54,7 +52,10 @@ class NoteService {
         data: {"space_id": spaceId},
       );
       Map json = response.data;
-      return json['notes'].map<Note>((e) => Note.fromJson(e)).toList();
+      return await Future.wait(json['notes']
+          .map<Future<Note?>>(
+              (e) => noteService.getNote(noteId: e['note']['_id']))
+          .toList());
     } catch (e) {
       print(e);
     }
@@ -71,7 +72,7 @@ class NoteService {
         data: {"note_id": noteId, "body": body},
       );
       Map json = response.data;
-      return Note.fromJson(json['note']);
+      return await this.getNote(noteId: json['note']['_id']);
     } catch (e) {
       print(e);
     }

--- a/app/mobile/lib/view/course/coursepage.dart
+++ b/app/mobile/lib/view/course/coursepage.dart
@@ -228,8 +228,8 @@ Widget coursePageView(Course c) => ViewModelBuilder<
                             padding: const EdgeInsets.all(10.0),
                             children: [
                               ...(viewModel.course!.notes ?? [])
-                                  .map((Note n) => GestureDetector(
-                                        child: mockTile(n.title ),
+                                  .map((Note? n) => GestureDetector(
+                                        child: mockTile(n!.title ),
                                         onTap: () => PersistentNavBarNavigator
                                             .pushNewScreen(context,
                                                 screen: noteView(note: n ),

--- a/app/mobile/lib/view/course/note/note_view.dart
+++ b/app/mobile/lib/view/course/note/note_view.dart
@@ -1,8 +1,10 @@
 import 'package:bucademy/classes/note/note.dart';
+import 'package:bucademy/resources/constants.dart';
 import 'package:bucademy/resources/custom_colors.dart';
 import 'package:bucademy/services/locator.dart';
 import 'package:bucademy/view/widgets/markdown_input.dart';
 import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:stacked/stacked.dart';
 
 String initialText = "## Realism \n- Photorealism\n- Abstract\n- Surrealism ";
@@ -14,6 +16,35 @@ Widget noteView({required Note note}) =>
         appBar: AppBar(
           title: Text(note.title),
           backgroundColor: CustomColors.main,
+          actions: [
+            GestureDetector(
+              child: const Icon(Icons.share),
+              onTap: () {
+                Share.share('${Constants.frontendUrl}/note/${note.id}');
+              },
+            ),
+            if (note.creator.id != userService.user?.id)
+              Row(
+                children: [
+                  const SizedBox(width: 10),
+                  GestureDetector(
+                    child: const Icon(Icons.copy),
+                    onTap: () async {
+                      Note? createdNote = await noteService.postNote(
+                          title: note.title,
+                          body: note.body,
+                          resourceId: note.resource.id);
+                      if (createdNote != null) {
+                        // ignore: use_build_context_synchronously
+                        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                            content:
+                                Text('This note has been copied to your notes')));
+                      }
+                    },
+                  ),
+                ],
+              )
+          ],
         ),
         body: viewModel.loading
             ? const Center(child: CircularProgressIndicator())
@@ -26,6 +57,8 @@ Widget noteView({required Note note}) =>
                   sendText: "Save",
                   sendIcon: Icons.save_rounded,
                   prewiewFirst: true,
+                  disableEdit: note.creator.id != userService.user?.id,
+                  disableSave: note.creator.id != userService.user?.id,
                 ),
               ),
       ),

--- a/app/mobile/lib/view/intro/intro.dart
+++ b/app/mobile/lib/view/intro/intro.dart
@@ -1,9 +1,12 @@
+import 'package:bucademy/classes/note/note.dart';
 import 'package:bucademy/resources/constants.dart';
 import 'package:bucademy/resources/custom_colors.dart';
 import 'package:bucademy/resources/text_styles.dart';
 import 'package:bucademy/services/locator.dart';
+import 'package:bucademy/view/course/note/note_view.dart';
 import 'package:bucademy/view/dashboard_view.dart';
 import 'package:flutter/material.dart';
+import 'package:persistent_bottom_nav_bar/persistent_tab_view.dart';
 import 'package:stacked/stacked.dart';
 import 'package:uni_links/uni_links.dart';
 import '../login/login.dart';
@@ -39,27 +42,28 @@ class IntroViewModel extends ChangeNotifier {
     }
     // Get the initial link
     Uri? initialLink = await getInitialUri();
-    await handleInitialLink(initialLink);
-    await Future.wait([
-      userService.refresh(),
-      Future.delayed(const Duration(seconds: 1)),
-    ]);
+    await userService.refresh();
     if (!mounted) return;
+    bool isRedirected = await handleInitialLink(initialLink, context: context);
+    if (isRedirected) return;
     Navigator.of(context).pushAndRemoveUntil(
         MaterialPageRoute(builder: (context) => const DashboardView()),
         (route) => false);
   }
 }
 
-handleInitialLink(Uri? initialLink, {BuildContext? context}) async {
-  if (initialLink == null) return;
+Future<bool> handleInitialLink(Uri? initialLink,
+    {BuildContext? context}) async {
+  // initialLink = Uri(path: "note/638b4d8935ed7f33a041b4e3"); // this is left for testing purposes since testing deep links is not trivial
+
+  if (initialLink == null) return false;
   if (initialLink.path.contains('confirmation/')) {
     // user clicked the link in the confirmation email
     List<String> parts = initialLink.path.split('confirmation/');
-    if (parts.length < 2) return;
+    if (parts.length < 2) return false;
     String token = parts[1];
     bool isSucessful = await userService.confirmMail(code: token);
-    if (!isSucessful) return;
+    if (!isSucessful) return false;
     if (context != null) {
       await Future.any([
         Future.delayed(const Duration(seconds: 5)),
@@ -97,6 +101,24 @@ handleInitialLink(Uri? initialLink, {BuildContext? context}) async {
       Navigator.of(context).pushAndRemoveUntil(
           MaterialPageRoute(builder: (context) => introView()),
           (route) => false);
+      return true;
     }
+  } else if (initialLink.path.contains('note/')) {
+    List<String> parts = initialLink.path.split('note/');
+    if (parts.length < 2) return false;
+    String noteId = parts[1];
+
+    Note? note = await noteService.getNote(noteId: noteId);
+    if (note == null || context == null) return false;
+
+    // ignore: use_build_context_synchronously
+    Navigator.of(context).pushAndRemoveUntil(
+        MaterialPageRoute(builder: (context) => const DashboardView()),
+        (route) => false);
+    // ignore: use_build_context_synchronously
+    PersistentNavBarNavigator.pushNewScreen(context,
+        screen: noteView(note: note), withNavBar: false);
+    return true;
   }
+  return false;
 }

--- a/app/mobile/lib/view/widgets/markdown_input.dart
+++ b/app/mobile/lib/view/widgets/markdown_input.dart
@@ -13,6 +13,8 @@ Widget markdownInput(
   String sendText = 'Send',
   bool prewiewFirst = false,
   bool withBorderRadius = false,
+  bool disableEdit = false,
+  bool disableSave = false,
 }) =>
     ViewModelBuilder<MarkdownInputViewModel>.reactive(
       viewModelBuilder: () => MarkdownInputViewModel(),
@@ -32,10 +34,13 @@ Widget markdownInput(
                 decoration: BoxDecoration(
                     color: CustomColors.main,
                     borderRadius: withBorderRadius
-                        ? const BorderRadiusDirectional.only(topEnd: Radius.circular(10), topStart: Radius.circular(10))
+                        ? const BorderRadiusDirectional.only(
+                            topEnd: Radius.circular(10),
+                            topStart: Radius.circular(10))
                         : BorderRadiusDirectional.circular(0)),
                 child: Row(
                   children: [
+                    if(disableSave != true)
                     ChangeViewButton(
                       icon: Icons.edit,
                       text: 'Edit',
@@ -51,23 +56,24 @@ Widget markdownInput(
                       isActive: viewModel.preview == true,
                     ),
                     const Spacer(),
-                    InkWell(
-                      onTap: (() async {
-                        if (onSend != null) {
-                          await onSend();
-                        }
-                        viewModel.updateScreen(isPreview: viewModel.preview);
-                      }),
-                      child: Row(
-                        children: [
-                          if (onSend != null)
-                            Icon(sendIcon, color: Colors.white),
-                          const SizedBox(width: 5),
-                          Text(sendText,
-                              style: const TextStyle(color: Colors.white)),
-                        ],
+                    if (disableEdit != true)
+                      InkWell(
+                        onTap: (() async {
+                          if (onSend != null) {
+                            await onSend();
+                          }
+                          viewModel.updateScreen(isPreview: viewModel.preview);
+                        }),
+                        child: Row(
+                          children: [
+                            if (onSend != null)
+                              Icon(sendIcon, color: Colors.white),
+                            const SizedBox(width: 5),
+                            Text(sendText,
+                                style: const TextStyle(color: Colors.white)),
+                          ],
+                        ),
                       ),
-                    ),
                     const SizedBox(width: 15),
                   ],
                 ),
@@ -105,7 +111,7 @@ Widget markdownInput(
 class ChangeViewButton extends StatelessWidget {
   final String text;
   final IconData icon;
-  final void Function() onTap;
+  final void Function()? onTap;
   final bool isActive;
   final bool withBorderRadius;
   const ChangeViewButton({

--- a/app/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,10 +5,14 @@
 import FlutterMacOS
 import Foundation
 
+import path_provider_macos
+import share_plus_macos
 import shared_preferences_macos
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/app/mobile/pubspec.lock
+++ b/app/mobile/pubspec.lock
@@ -148,6 +148,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.3+2"
   crypto:
     dependency: transitive
     description:
@@ -429,6 +436,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.11"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.22"
+  path_provider_ios:
+    dependency: transitive
+    description:
+      name: path_provider_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.11"
   path_provider_linux:
     dependency: transitive
     description:
@@ -436,6 +464,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.7"
+  path_provider_macos:
+    dependency: transitive
+    description:
+      name: path_provider_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.6"
   path_provider_platform_interface:
     dependency: transitive
     description:
@@ -520,6 +555,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0+1"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.0"
+  share_plus_linux:
+    dependency: transitive
+    description:
+      name: share_plus_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1"
+  share_plus_macos:
+    dependency: transitive
+    description:
+      name: share_plus_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.2.0"
+  share_plus_web:
+    dependency: transitive
+    description:
+      name: share_plus_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.0"
+  share_plus_windows:
+    dependency: transitive
+    description:
+      name: share_plus_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -770,6 +847,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.7"
   vector_math:
     dependency: transitive
     description:

--- a/app/mobile/pubspec.yaml
+++ b/app/mobile/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   uni_links: ^0.5.1
   url_launcher: ^6.1.7
   email_validator: ^2.1.17
+  share_plus: 4.2.0
   
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
Closes #469
- Modified handleInitialLink function to support opening note pages via deep links
- Added  `share_plus` library to make it easier to share notes
- Changed note class, added `creator` field, according to latest backend specifications 
![share-note](https://user-images.githubusercontent.com/15876225/209481724-79b65d9d-e684-43cf-9a86-5c95832c0b43.gif)



- Note that deep links only work in release mode, since in [assetlinks.json](https://bucademy.tk/.well-known/assetlinks.json) file we are hosting, only the release key's hash is registered. You can try with `flutter run --release` command. 